### PR TITLE
feat: implementasi status pendaftaran relawan dan isolasi data (CAP-68)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
-<<<<<<< HEAD
     "@types/node": "^25.6.0",
-=======
->>>>>>> feat/CAP-65-status-guard
     "@types/pg": "^8.20.0",
     "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.10",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -13,9 +13,11 @@ export const missions = pgTable("missions", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   title: varchar({ length: 255 }).notNull(),
   description: text().notNull(),
+  location: varchar({ length: 255 }).notNull().default("Remote"), 
   status: varchar({ length: 50 }).notNull().default("menunggu_relawan"),
   volunteersNeeded: integer("volunteers_needed").notNull().default(0),
   volunteersApplied: integer("volunteers_applied").notNull().default(0),
+  coordinatorWhatsapp: varchar("coordinator_whatsapp", { length: 20 }), 
   createdAt: timestamp("created_at").defaultNow(),
 });
 

--- a/src/routes/api/apply.ts
+++ b/src/routes/api/apply.ts
@@ -6,22 +6,65 @@ import { eq, and } from "drizzle-orm";
 
 const router: Router = express.Router();
 
-// --- GET MY APPLICATIONS (CAP-63) ---
-router.get("/me", (req: Request, res: Response) => {
-  res.status(200).json({ message: "get my applications endpoint" });
+/**
+ * Endpoint untuk mendapatkan riwayat pendaftaran relawan.
+ * Mengimplementasikan isolasi data agar relawan hanya bisa melihat aplikasi miliknya sendiri.
+ */
+router.get("/me/status", authMiddleware, authorizeRole("volunteer"), async (req: Request, res: Response) => {
+  const userId = (req as any).user?.id;
+
+  try {
+    // Menggunakan LEFT JOIN agar data pendaftaran tetap aman meskipun misi terkait dihapus
+    const userApplications = await db.select({
+      application_id: applications.id,
+      mission_id: applications.missionId,
+      mission_title: missions.title,
+      mission_location: missions.location, 
+      application_status: applications.status,
+      applied_at: applications.createdAt,
+      coordinator_whatsapp: missions.coordinatorWhatsapp,
+    })
+    .from(applications)
+    .leftJoin(missions, eq(applications.missionId, missions.id))
+    .where(eq(applications.volunteerId, userId));
+
+    const formattedData = userApplications.map((app) => ({
+      application_id: app.application_id,
+      mission_id: app.mission_id,
+      // Fallback jika judul misi tidak ditemukan (misi dihapus)
+      mission_title: app.mission_title ?? "[Misi dihapus]",
+      mission_location: app.mission_location ?? "N/A",
+      application_status: app.application_status,
+      applied_at: app.applied_at,
+      /**
+       * Kontrol akses informasi: Nomor WhatsApp koordinator hanya 
+       * ditampilkan jika pendaftaran sudah disetujui (Approved).
+       */
+      coordinator_whatsapp: app.application_status === "approved" ? app.coordinator_whatsapp : null
+    }));
+
+    return res.status(200).json({ applications: formattedData });
+
+  } catch (error) {
+    console.error("Fetch Status Error:", error);
+    return res.status(500).json({ message: "Internal server error" });
+  }
 });
 
-// Menambahkan generic type <{ mission_id: string }> agar params tidak merah
+/**
+ * Endpoint untuk mendaftarkan relawan ke sebuah misi.
+ * Mencakup validasi keberadaan misi, status pendaftaran, kuota, dan pencegahan duplikasi.
+ */
 router.post("/:mission_id/apply", 
   authMiddleware, 
   authorizeRole("volunteer"), 
   async (req: Request<{ mission_id: string }>, res: Response) => {
     const { mission_id } = req.params;
     const missionId = parseInt(mission_id);
-    const userId = (req as any).user?.id; // Tetap pakai any untuk user karena custom property dari middleware
+    const userId = (req as any).user?.id;
 
     try {
-      // 1. Guard: Existence (CAP-65 - 404)
+      // Validasi: Apakah misi eksis di database?
       const missionData = await db.select()
         .from(missions)
         .where(eq(missions.id, missionId))
@@ -36,7 +79,7 @@ router.post("/:mission_id/apply",
 
       const mission = missionData[0];
 
-      // 2. Guard: Status (CAP-65 - 409)
+      // Validasi: Apakah misi masih dalam periode penerimaan relawan?
       const allowedStatuses = ["menunggu_relawan", "sedang_berjalan"];
       if (!allowedStatuses.includes(mission.status)) {
         return res.status(409).json({ 
@@ -45,7 +88,7 @@ router.post("/:mission_id/apply",
         });
       }
 
-      // 3. Guard: Quota Check (CAP-66 - 409)
+      // Validasi: Cek apakah kuota relawan masih mencukupi
       const applied = mission.volunteersApplied ?? 0;
       const needed = mission.volunteersNeeded ?? 0;
 
@@ -56,7 +99,7 @@ router.post("/:mission_id/apply",
         });
       }
 
-      // 4. Guard: Duplicate Check (CAP-67 - 409)
+      // Validasi: Mencegah user mendaftar ulang pada misi yang sama
       const existingApply = await db.select()
         .from(applications)
         .where(
@@ -75,14 +118,13 @@ router.post("/:mission_id/apply",
         });
       }
 
-      // 5. Success Output
       return res.status(201).json({
         message: "Berhasil mendaftar misi!",
         data: { mission_id: missionId, status: "pending" }
       });
 
     } catch (error: any) {
-      // Handle Race Condition (Unique Constraint Violation)
+      // Penanganan khusus untuk menjaga integritas data (unique constraint)
       if (error.code === "23505") {
         return res.status(409).json({ 
           error: "ALREADY_APPLIED", 
@@ -93,6 +135,10 @@ router.post("/:mission_id/apply",
       console.error("Apply Mission Error:", error);
       return res.status(500).json({ message: "Internal server error" });
     }
+});
+
+router.get("/me", (req: Request, res: Response) => {
+  res.status(200).json({ message: "get my applications endpoint" });
 });
 
 export default router;


### PR DESCRIPTION
Perubahan Utama:
- Endpoint Baru: Menambahkan GET /me/status untuk melihat daftar pendaftaran relawan.
- Isolasi Data: Memastikan relawan hanya bisa melihat data pendaftaran milik sendiri (filter berdasarkan userId).
- Proteksi Privasi: Nomor WhatsApp koordinator hanya ditampilkan jika status pendaftaran sudah approved.
- Update Skema: Menambahkan kolom location dan coordinator_whatsapp pada tabel missions.

Teknis:
- Menggunakan leftJoin antara tabel applications dan missions untuk menjaga integritas riwayat pendaftaran.
- Sinkronisasi database telah dilakukan menggunakan drizzle-kit push.